### PR TITLE
Add OvershareKit podspec

### DIFF
--- a/OvershareKit.podspec
+++ b/OvershareKit.podspec
@@ -1,0 +1,22 @@
+Pod::Spec.new do |s|
+  s.name         = "OvershareKit"
+  s.version      = "0.0.1"
+  s.summary      = "A soup-to-nuts sharing library for iOS."
+  s.homepage     = "https://github.com/overshare/overshare-kit"
+  s.license      = { :type => 'MIT', :file => 'LICENSE'  }
+  s.author       = { "Jared Sinclair" => "email@here", "Justin Williams" => "email@here" }
+  s.source       = { :git => "https://github.com/overshare/overshare-kit.git" } #:tag => s.version.to_s }
+  s.platform     = :ios, '7.0'
+  s.requires_arc = true
+  s.frameworks   = 'UIKit'
+  
+  s.compiler_flags = "-fmodules"
+  
+  s.ios.deployment_target = '7.0'
+  
+  s.source_files = ['Overshare Kit/*.{h,m}']
+  s.resources    = ['Overshare Kit/Images/*', 'Overshare Kit/*.xib']
+  
+  s.dependency 'ADNLogin'
+  s.dependency 'PocketAPI'
+end


### PR DESCRIPTION
I've started on an OvershareKit podspec as per #1.

This podspec lints cleanly with `pod spec lint`. There's a few more things to do:
- [x] Push a tag to OvershareKit, update tag ref in the podspec
- [x] Add your email addresses to the podspec
