### PR TITLE
Podspec tweaks/warning fix

### DIFF
--- a/Overshare Kit/OSKFacebookUtility.m
+++ b/Overshare Kit/OSKFacebookUtility.m
@@ -45,7 +45,7 @@
     SLRequestHandler requestHandler = ^(NSData *responseData, NSHTTPURLResponse *urlResponse, NSError *error) {
         if (responseData != nil) {
             
-            NSString *response = [[NSString alloc] initWithData:responseData encoding:NSUTF8StringEncoding];
+            __unused NSString *response = [[NSString alloc] initWithData:responseData encoding:NSUTF8StringEncoding];
             OSKLog(@"%@", response);
             
             NSInteger statusCode = urlResponse.statusCode;

--- a/OvershareKit.podspec
+++ b/OvershareKit.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
   s.name         = "OvershareKit"
-  s.version      = “1.0.1”
+  s.version      = "1.0.1"
   s.summary      = "A soup-to-nuts sharing library for iOS."
   s.homepage     = "https://github.com/overshare/overshare-kit"
   s.license      = { :type => 'MIT', :file => 'LICENSE'  }
-  s.author       = { "Jared Sinclair" => “desk”@jaredsinclair.com, "Justin Williams" => "email@here" }
-  s.source       = { :git => "https://github.com/overshare/overshare-kit.git" } #:tag => s.version.to_s }
+  s.author       = { "Jared Sinclair" => "desk@jaredsinclair.com", "Justin Williams" => "justin@carpeaqua.com" }
+  s.source       = { :git => "https://github.com/overshare/overshare-kit.git", :tag => s.version.to_s }
   s.platform     = :ios, '7.0'
   s.requires_arc = true
   s.frameworks   = 'UIKit'


### PR DESCRIPTION
Some minor podspec tweaks:
- Use dumb quotes
- Fix up emails
- Add spec tag

Cocoapods will not accept specs that lint with warnings. OvershareKit has one minor warning:

`OvershareKit/Overshare Kit/OSKFacebookUtility.m:48:23: warning: unused variable 'response' [-Wunused-variable]`

Fixed by applying `__unused`.
