### PR TITLE
Add @import for UIKit in OSKInMemoryImageCache.h

### DIFF
--- a/Overshare Kit/OSKInMemoryImageCache.h
+++ b/Overshare Kit/OSKInMemoryImageCache.h
@@ -7,6 +7,7 @@
 //
 
 @import Foundation;
+@import UIKit;
 
 @interface OSKInMemoryImageCache : NSCache
 


### PR DESCRIPTION
This was failing to build on Xcode 5.1 Seems you need `@import UIKit;`
to work. Also will need to update the project libraries as Xcode 5.1 has
a newer UIKit.framwork
