### PR TITLE
Latest cocoapod does not compile when using Objective-C modules

### DIFF
--- a/OvershareKit.podspec
+++ b/OvershareKit.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/overshare/overshare-kit.git", :tag => s.version.to_s }
   s.platform     = :ios, '7.0'
   s.requires_arc = true
-  s.frameworks   = 'UIKit'
+  s.frameworks   = 'UIKit', 'AddressBook', 'CoreMotion', 'CoreLocation'
   
   s.compiler_flags = "-fmodules"
   


### PR DESCRIPTION
If you delete all frameworks from XCode link build phase(like we probably should do on any project to speed up build time), OvershareKit stops building and throws linker errors. 

I've added 3 framework dependencies in podspec to automatically include them to project using OverShareKit. I've also added latest(1.1.0) podspec changes from CocoaPods Specs repo.
