### PR TITLE
Fix some warnings and expose a method to manually dismiss the activity sheet

### DIFF
--- a/Overshare Kit/OSKAccountManagementViewController.h
+++ b/Overshare Kit/OSKAccountManagementViewController.h
@@ -13,4 +13,6 @@
 - (instancetype)initWithIgnoredActivityClasses:(NSArray *)ignoredActivityClasses
                 optionalBespokeActivityClasses:(NSArray *)arrayOfClasses;
 
+@property (nonatomic, assign) BOOL showsDoneButton; // defaults to YES
+
 @end

--- a/Overshare Kit/OSKAccountManagementViewController.m
+++ b/Overshare Kit/OSKAccountManagementViewController.m
@@ -94,8 +94,7 @@ static NSString * OSKAccountManagementHeaderViewIdentifier = @"OSKAccountManagem
     if (self) {
         
         self.title = @"Sharing";
-        NSString *doneTitle = [[OSKPresentationManager sharedInstance] localizedText_Done];
-        self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:doneTitle style:UIBarButtonItemStyleDone target:self action:@selector(cancelButtonPressed:)];
+        _showsDoneButton = YES;
 
         [self setupManagedAccountClasses:ignoredActivityClasses optionalBespokeActivityClasses:arrayOfClasses];
         [self setupToggleClasses:ignoredActivityClasses optionalBespokeActivityClasses:arrayOfClasses];
@@ -212,6 +211,11 @@ static NSString * OSKAccountManagementHeaderViewIdentifier = @"OSKAccountManagem
     [self.tableView registerClass:[OSKAccountTypeCell class] forCellReuseIdentifier:OSKAccountTypeCellIdentifier];
     [self.tableView registerClass:[OSKActivityToggleCell class] forCellReuseIdentifier:OSKActivityToggleCellIdentifier];
     [self.tableView registerClass:[OSKAccountManagementHeaderView class] forHeaderFooterViewReuseIdentifier:OSKAccountManagementHeaderViewIdentifier];
+
+    if (self.showsDoneButton) {
+        NSString *doneTitle = [[OSKPresentationManager sharedInstance] localizedText_Done];
+        self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:doneTitle style:UIBarButtonItemStyleDone target:self action:@selector(cancelButtonPressed:)];
+    }
 }
 
 - (void)viewWillAppear:(BOOL)animated {

--- a/Overshare Kit/OSKActivitiesManager.m
+++ b/Overshare Kit/OSKActivitiesManager.m
@@ -195,10 +195,12 @@ static NSString * OSKActivitiesManagerPersistentExclusionsKey = @"OSKActivitiesM
             if ([[activityClass supportedContentItemType] isEqualToString:item.itemType]) {
                 NSString *type = objc_msgSend(activityClass, @selector(activityType));
                 if ([excludedActivityTypes containsObject:type] == NO) {
-                    if ((requireOperations && [activityClass canPerformViaOperation]) || requireOperations == NO) {
-                        OSKActivity *activity = [[activityClass alloc] initWithContentItem:item];
-                        if (activity) {
-                            [validActivities addObject:activity];
+                    if ([activityClass isAvailable]) {
+                        if ((requireOperations && [activityClass canPerformViaOperation]) || requireOperations == NO) {
+                            OSKActivity *activity = [[activityClass alloc] initWithContentItem:item];
+                            if (activity) {
+                                [validActivities addObject:activity];
+                            }
                         }
                     }
                 }

--- a/Overshare Kit/OSKActivitiesManager.m
+++ b/Overshare Kit/OSKActivitiesManager.m
@@ -38,6 +38,7 @@
 #import "OSKSMSActivity.h"
 #import "OSKThingsActivity.h"
 #import "OSKTwitterActivity.h"
+#import <objc/message.h>
 
 #if DEBUG == 1
 // DEVELOPMENT KEYS ONLY, YOUR APP SHOULD SUPPLY YOUR APP CREDENTIALS VIA THE CUSTOMIZATIONS DELEGATE.
@@ -192,7 +193,7 @@ static NSString * OSKActivitiesManagerPersistentExclusionsKey = @"OSKActivitiesM
         for (id activityClass in bespokeActivities) {
             NSAssert([activityClass respondsToSelector:@selector(supportedContentItemType)], @"The bespokeActivities array must contain classes inheriting from OSKActivity, not actual instances of the class.");
             if ([[activityClass supportedContentItemType] isEqualToString:item.itemType]) {
-                NSString *type = [activityClass activityType];
+                NSString *type = objc_msgSend(activityClass, @selector(activityType));
                 if ([excludedActivityTypes containsObject:type] == NO) {
                     if ((requireOperations && [activityClass canPerformViaOperation]) || requireOperations == NO) {
                         OSKActivity *activity = [[activityClass alloc] initWithContentItem:item];

--- a/Overshare Kit/OSKActivityIndicatorItem.m
+++ b/Overshare Kit/OSKActivityIndicatorItem.m
@@ -50,6 +50,10 @@
     [self.spinner setPosition:position];
 }
 
+- (OSKActivityIndicatorItemPosition)position {
+    return self.spinner.position;
+}
+
 - (void)startSpinning {
     [self.spinner startAnimating];
 }

--- a/Overshare Kit/OSKChromeActivity.m
+++ b/Overshare Kit/OSKChromeActivity.m
@@ -134,7 +134,12 @@ static NSString * OSKChromeActivity_URLQueryKey = @"url";
     [[UIApplication sharedApplication] openURL:chromeURL];
     
     if (completion) {
-        completion(self, YES, nil);
+        if (chromeURL != nil) {
+            completion(self, YES, nil);
+        } else {
+            NSError *error = [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorBadURL userInfo:nil];
+            completion(self, NO, error);
+        }
     }
 }
 

--- a/Overshare Kit/OSKPagedHorizontalLayout.m
+++ b/Overshare Kit/OSKPagedHorizontalLayout.m
@@ -10,9 +10,9 @@
 
 @interface OSKPagedHorizontalLayout ()
 
-@property (assign, nonatomic) CGFloat availableWidth;
-@property (assign, nonatomic) CGFloat availableHeight;
-@property (assign, nonatomic) UIEdgeInsets edgeInsets;
+@property (readonly, nonatomic) CGFloat availableWidth;
+@property (readonly, nonatomic) CGFloat availableHeight;
+@property (readonly, nonatomic) UIEdgeInsets edgeInsets;
 @property (strong, nonatomic) NSArray *attributes;
 @property (assign, nonatomic) NSInteger numberOfPages;
 

--- a/Overshare Kit/OSKPresentationLocalization.h
+++ b/Overshare Kit/OSKPresentationLocalization.h
@@ -38,6 +38,7 @@
 - (NSString *)osk_localizedText_Username;
 - (NSString *)osk_localizedText_Email;
 - (NSString *)osk_localizedText_Password;
+- (NSString *)osk_localizedText_1PasswordPrompt;
 - (NSString *)osk_localizedText_SignOut;
 - (NSString *)osk_localizedText_SignIn;
 - (NSString *)osk_localizedText_AreYouSure;

--- a/Overshare Kit/OSKPresentationManager.h
+++ b/Overshare Kit/OSKPresentationManager.h
@@ -303,6 +303,7 @@ extern NSString * const OSKPresentationOption_PresentationEndingHandler;
 - (NSString *)localizedText_Username;
 - (NSString *)localizedText_Email;
 - (NSString *)localizedText_Password;
+- (NSString *)localizedText_1PasswordPrompt;
 - (NSString *)localizedText_Accounts;
 - (NSString *)localizedText_SignOut;
 - (NSString *)localizedText_SignIn;

--- a/Overshare Kit/OSKPresentationManager.h
+++ b/Overshare Kit/OSKPresentationManager.h
@@ -135,6 +135,17 @@ extern NSString * const OSKPresentationOption_PresentationEndingHandler;
                               animated:(BOOL)animated
                                options:(NSDictionary *)options;
 
+/**
+ Dismisses the activity sheet.
+ 
+ @param animated Pass YES to animate the transition.
+ @param completion A block called after the sheet has been dismissed.
+ 
+ @note if an instance of `OSKPresentationEndingHandler` was specified in the options while presenting,
+ it is called with the presentation ending `OSKPresentationEnding_Cancelled`.
+ */
+- (void)dismissActivitySheetAnimated:(BOOL)animated completion:(void(^)(void))completion;
+
 ///---------------------------------------------------
 /// @name Skipping the Built-In Activity Sheet
 ///---------------------------------------------------

--- a/Overshare Kit/OSKPresentationManager.m
+++ b/Overshare Kit/OSKPresentationManager.m
@@ -855,6 +855,17 @@ willRepositionPopoverToRect:(inout CGRect *)rect
     return text;
 }
 
+- (NSString *)localizedText_1PasswordPrompt {
+    NSString *text = nil;
+    if ([self.localizationDelegate respondsToSelector:@selector(osk_localizedText_1PasswordPrompt)]) {
+        text = [self.localizationDelegate osk_localizedText_1PasswordPrompt];
+    }
+    if (text == nil) {
+        text = @"1Password";
+    }
+    return text;
+}
+
 - (NSString *)localizedText_SignOut {
     NSString *text = nil;
     if ([self.localizationDelegate respondsToSelector:@selector(osk_localizedText_SignOut)]) {

--- a/Overshare Kit/OSKShareableContent.h
+++ b/Overshare Kit/OSKShareableContent.h
@@ -159,6 +159,7 @@ These can be custom items, or additional instances of the official items above.
  Convenient constructor for content drawn from microblog posts (like Twitter or App.net).
  */
 + (instancetype)contentFromMicroblogPost:(NSString *)text
+                                   title:(NSString *)title
                               authorName:(NSString *)authorName
                             canonicalURL:(NSString *)canonicalURL
                                   images:(NSArray *)images;

--- a/Overshare Kit/OSKShareableContent.m
+++ b/Overshare Kit/OSKShareableContent.m
@@ -120,7 +120,7 @@
     return content;
 }
 
-+ (instancetype)contentFromMicroblogPost:(NSString *)text authorName:(NSString *)authorName canonicalURL:(NSString *)canonicalURL images:(NSArray *)images {
++ (instancetype)contentFromMicroblogPost:(NSString *)text title:(NSString *)title authorName:(NSString *)authorName canonicalURL:(NSString *)canonicalURL images:(NSArray *)images {
     OSKShareableContent *content = [[OSKShareableContent alloc] init];
     
     content.title = [NSString stringWithFormat:@"Post by %@: “%@”", authorName, text];
@@ -166,7 +166,7 @@
     
     OSKEmailContentItem *emailItem = [[OSKEmailContentItem alloc] init];
     emailItem.body = [NSString stringWithFormat:@"“%@”\n\n(Via %@)\n\n%@ ", text, authorName, canonicalURL];
-    emailItem.subject = @"Clipper Ships Sail On the Ocean";
+    emailItem.subject = title ?: [NSString stringWithFormat:@"Post by %@", authorName];
     emailItem.attachments = images.copy;
     content.emailItem = emailItem;
     
@@ -178,7 +178,7 @@
     if (URLforCanonicalURL) {
         OSKReadLaterContentItem *readLater = [[OSKReadLaterContentItem alloc] init];
         readLater.url = URLforCanonicalURL;
-        readLater.title = [NSString stringWithFormat:@"Post by %@", authorName];
+        readLater.title = title ?: [NSString stringWithFormat:@"Post by %@", authorName];
         readLater.description = text;
         content.readLaterItem = readLater;
         
@@ -196,7 +196,7 @@
     }
     
     OSKToDoListEntryContentItem *toDoList = [[OSKToDoListEntryContentItem alloc] init];
-    toDoList.title = [NSString stringWithFormat:@"Look into message from %@", authorName];
+    toDoList.title = title ?: [NSString stringWithFormat:@"Look into message from %@", authorName];
     toDoList.notes = [NSString stringWithFormat:@"%@\n\n%@", text, canonicalURL];
     content.toDoListItem = toDoList;
     

--- a/Overshare Kit/OSKShareableContent.m
+++ b/Overshare Kit/OSKShareableContent.m
@@ -144,7 +144,7 @@
     content.facebookItem = facebook;
     
     OSKMicroblogPostContentItem *microblogPost = [[OSKMicroblogPostContentItem alloc] init];
-    microblogPost.text = [NSString stringWithFormat:@"“%@” (Via @%@) %@ ", text, authorName, canonicalURL];
+    microblogPost.text = [NSString stringWithFormat:@"“%@” (Via %@) %@ ", text, authorName, canonicalURL];
     microblogPost.images = images;
     content.microblogPostItem = microblogPost;
     
@@ -165,7 +165,7 @@
     content.additionalItems = @[copyURLToPasteboard];
     
     OSKEmailContentItem *emailItem = [[OSKEmailContentItem alloc] init];
-    emailItem.body = [NSString stringWithFormat:@"“%@”\n\n(Via @%@)\n\n%@ ", text, authorName, canonicalURL];
+    emailItem.body = [NSString stringWithFormat:@"“%@”\n\n(Via %@)\n\n%@ ", text, authorName, canonicalURL];
     emailItem.subject = @"Clipper Ships Sail On the Ocean";
     emailItem.attachments = images.copy;
     content.emailItem = emailItem;

--- a/Overshare Kit/OSKUsernamePasswordViewController.m
+++ b/Overshare Kit/OSKUsernamePasswordViewController.m
@@ -122,7 +122,7 @@
         if (cell == nil) {
             cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:onePasswordCellIdentifier];
             cell.textLabel.textAlignment = NSTextAlignmentCenter;
-            cell.textLabel.text = @"1Password";
+            cell.textLabel.text = [[OSKPresentationManager sharedInstance] localizedText_1PasswordPrompt];
             OSKPresentationManager *presentationManager = [OSKPresentationManager sharedInstance];
             cell.textLabel.textColor = [presentationManager color_action];
             cell.backgroundColor = [presentationManager color_groupedTableViewCells];


### PR DESCRIPTION
I've found that linking both overshare-kit and CoreLocation results in a build error. Moreover the subject of e-mail activities was hardcoded to some placeholder text, I've added the possibility to specify a custom title/subject for micropost blogs in the convenience constructor.

Let me know what you think and thanks a lot for this great framework,

cheers Matthias
