### PR TITLE
OSKEmailActivity & OSKSMSActivity can publish items with attachments, bu...

### DIFF
--- a/Overshare Kit/OSKEmailActivity.m
+++ b/Overshare Kit/OSKEmailActivity.m
@@ -64,7 +64,7 @@
 }
 
 - (BOOL)isReadyToPerform {
-    return [(OSKEmailContentItem *)self.contentItem body].length > 0;
+    return [(OSKEmailContentItem *)self.contentItem body].length > 0 || [(OSKEmailContentItem *)self.contentItem attachments].count;
 }
 
 - (void)performActivity:(OSKActivityCompletionHandler)completion {

--- a/Overshare Kit/OSKSMSActivity.m
+++ b/Overshare Kit/OSKSMSActivity.m
@@ -62,7 +62,7 @@
 }
 
 - (BOOL)isReadyToPerform {
-    return [(OSKSMSContentItem *)self.contentItem body].length > 0;
+    return [(OSKSMSContentItem *)self.contentItem body].length > 0 || [(OSKSMSContentItem *)self.contentItem attachments].count;
 }
 
 - (void)performActivity:(OSKActivityCompletionHandler)completion {


### PR DESCRIPTION
If a ActivitySheet is shown for shareable content with an image, but no captions, isReadyToPerform will return false, but the action will still happen. For SMS messages, the option to close the modal will also disappear. This patch checks the number of attachments in addition to the content length, and proceeds if either satisfy.

To reproduce:

```
OSKShareableContent * content = [OSKShareableContent contentFromImages:images caption:nil];
OSKActivitiesManager *manager = [OSKActivitiesManager sharedInstance];
[[OSKPresentationManager sharedInstance] presentActivitySheetForContent:content presentingViewController:self options:nil];
```
