### PR TITLE
Add support for mime attachments to email messages other than images

### DIFF
--- a/Overshare Kit/OSKMailComposeViewController.m
+++ b/Overshare Kit/OSKMailComposeViewController.m
@@ -10,6 +10,7 @@
 
 #import "OSKEmailActivity.h"
 #import "OSKShareableContentItem.h"
+#import "OSKMimeAttachment.h"
 
 @interface OSKMailComposeViewController () <MFMailComposeViewControllerDelegate, UINavigationControllerDelegate>
 
@@ -40,24 +41,27 @@
 - (void)preparePublishingViewForActivity:(OSKActivity *)activity delegate:(id <OSKPublishingViewControllerDelegate>)oskPublishingDelegate {
     [self setActivity:(OSKEmailActivity *)activity];
     [self setOskPublishingDelegate:oskPublishingDelegate];
-    
+
     [self setActivity:(OSKEmailActivity *)activity];
     [self setOskPublishingDelegate:oskPublishingDelegate];
-    
+
     OSKEmailContentItem *emailItem = (OSKEmailContentItem *)activity.contentItem;
-    
+
     [self setSubject:emailItem.subject];
     [self setMessageBody:emailItem.body isHTML:emailItem.isHTML];
     [self setToRecipients:emailItem.toRecipients];
     [self setCcRecipients:emailItem.ccRecipients];
     [self setBccRecipients:emailItem.bccRecipients];
-    
+
     for (id attachment in emailItem.attachments) {
         if ([attachment isKindOfClass:[UIImage class]]) {
             UIImage *photo = (UIImage *)attachment;
             NSData *imageData = UIImageJPEGRepresentation(photo, 0.25);
             NSString *fileName = [NSString stringWithFormat:@"Image-%lu.jpg", (unsigned long)[emailItem.attachments indexOfObject:photo]];
             [self addAttachmentData:imageData mimeType:@"image/jpeg" fileName:fileName];
+        } else if ([attachment isKindOfClass:[OSKMimeAttachment class]]) {
+            OSKMimeAttachment *mimeAttachment = (OSKMimeAttachment *) attachment;
+            [self addAttachmentData:mimeAttachment.data mimeType:mimeAttachment.mimeType fileName:mimeAttachment.fileName];
         }
     }
 }

--- a/Overshare Kit/OSKMimeAttachment.h
+++ b/Overshare Kit/OSKMimeAttachment.h
@@ -1,0 +1,24 @@
+//
+//  OSKMimeAttachment.h
+//  OvershareKit
+//
+//  Created by Calman Steynberg on 2014-04-19.
+//  Copyright (c) 2014 Overshare Kit. All rights reserved.
+//
+
+@import Foundation;
+
+/**
+ `OSKMimeAttachment` is intended for use as in email messages only and allows arbitrary mime attachments.
+ Add instances of it to OKSEmailContentItem attachment property.
+*/
+
+@interface OSKMimeAttachment : NSObject
+
+@property (nonatomic, copy) NSString* mimeType;
+@property (nonatomic, copy) NSString* fileName;
+@property (nonatomic, strong) NSData* data;
+
+-(instancetype) initWithType:(NSString *)mimeType name:(NSString *)fileName data:(NSData *)data;
+
+@end

--- a/Overshare Kit/OSKMimeAttachment.m
+++ b/Overshare Kit/OSKMimeAttachment.m
@@ -1,0 +1,23 @@
+//
+//  OSKMimeAttachment.m
+//  OvershareKit
+//
+//  Created by Calman Steynberg on 2014-04-19.
+//  Copyright (c) 2014 Overshare Kit. All rights reserved.
+//
+
+#import "OSKMimeAttachment.h"
+
+@implementation OSKMimeAttachment
+
+-(instancetype) initWithType:(NSString *)mimeType name:(NSString *)fileName data:(NSData *)data {
+    self = [super init];
+    if (self) {
+        _mimeType = mimeType;
+        _fileName = fileName;
+        _data = data;
+    }
+    return self;
+}
+
+@end

--- a/Overshare Kit/OSKShareableContentItem.h
+++ b/Overshare Kit/OSKShareableContentItem.h
@@ -2,7 +2,7 @@
 //  OSKShareableContentItem.h
 //  Overshare
 //
-//   
+//
 //  Copyright (c) 2013 Overshare Kit. All rights reserved.
 //
 
@@ -29,10 +29,10 @@ extern NSString * const OSKShareableContentItemType_TextEditing;
 
 /**
  An abstract base class for the many kinds of shareable content items.
- 
+
  @discussion Never instantiate `OSKShareableContentItem` directly. You must use it via
  a subclass (either built-in or one of your own).
- 
+
  @see OSKShareableContent
  */
 @interface OSKShareableContentItem : NSObject
@@ -40,12 +40,12 @@ extern NSString * const OSKShareableContentItemType_TextEditing;
 /**
  An alternate name to be used in place of the default name of any `<OSKActivity>` that
  is handling the content item. The default is `nil`.
- 
+
  @discussion Useful for when you need multiple instances of the same content item, e.g.
  in Riposte, we have "Email Post" and "Email Conversation" in the
  conversation share sheet. If you don't set an alternate activity name, then the
  `<OSKActivity>`'s default name and icon will be used instead.
- 
+
  If all you need to do is localize an activity name, it is better to do that
  via the `customizationsDelegate` of `OSKPresentationManager`.
  */
@@ -60,40 +60,40 @@ extern NSString * const OSKShareableContentItemType_TextEditing;
 /**
  Returns either one of the officially supported item types listed above,
  or a custom item type.
- 
+
  @warning Required. Subclasses must override without calling super.
  */
 - (NSString *)itemType;
 
 /**
  Additional activity-specific or contextual info.
- 
+
  @discussion Third-party apps & services vary widely in the extra features they
  offer. Facebook is *in general* a microblogging activity, like ADN and Twitter,
- but in practice it has a few advanced needs. Rather than add dozens of properties 
- that are each only used by a single activity type, it makes more sense use an 
+ but in practice it has a few advanced needs. Rather than add dozens of properties
+ that are each only used by a single activity type, it makes more sense use an
  NSMutableDictionary to store activity-specific or app-specific contextual info.
- 
+
  To avoid conflicts, keys in this dictionary should be namespaced as follows:
- 
+
  com.<application>.<activityName>.<key>
- 
+
  For example, the key to an NSDictionary of Facebook post attributes would use
  a protected namespace as follows:
- 
+
  com.oversharekit.facebook.userInfo
- 
+
  Let's say there's an app called Foo.app that has integrated OvershareKit.
  It has also written a bespoke OSKActivity subclass, "FOOSelfieActivity." This
  activity is a microblogging activity, but it needs additional data to submit a post.
- It could add an NSDictionary of custom attributes to the userInfo dictionary 
+ It could add an NSDictionary of custom attributes to the userInfo dictionary
  with the following key:
- 
+
  com.fooapp.selfie.userInfo
- 
+
  This would allow Foo.app to add the Selfie activity without having to make awkward
  modifications to their OSK integration.
- 
+
  As OvershareKit matures, we may occasionally promote frequently-used data types
  stored in userInfo dictionaries to class-level @properties.
  */
@@ -117,7 +117,7 @@ extern NSString * const OSKShareableContentItemType_TextEditing;
 
 /**
  An optional array of `<UIImage>` objects to be attached to the outgoing post.
- 
+
  @discussion Not all activities support multiple images. Those that do not will simply
  ignore all but the first image in the array when creating a new post.
  */
@@ -140,7 +140,7 @@ extern NSString * const OSKShareableContentItemType_TextEditing;
 ///---------------------------------------------------
 
 /**
- Text content. The user should be provided an opportunity to edit this text prior to 
+ Text content. The user should be provided an opportunity to edit this text prior to
  publishing, per Facebook's API terms.
  */
 @interface OSKFacebookContentItem : OSKShareableContentItem
@@ -178,7 +178,7 @@ extern NSString * const OSKShareableContentItemType_TextEditing;
 
 /**
  Content for sharing to blogging services like Tumblr or WordPress.
- 
+
  @warning As of October 31, 2013, no activities in Overshare Kit are using this item.
  */
 @interface OSKBlogPostContentItem : OSKShareableContentItem
@@ -200,7 +200,7 @@ extern NSString * const OSKShareableContentItemType_TextEditing;
 
 /**
  An optional flag for creating the post in the drafts queue instead of immediately publishing the post.
- 
+
  Defaults to NO (publishes immediately).
  */
 @property (assign, nonatomic) BOOL publishAsDraft;
@@ -237,8 +237,8 @@ extern NSString * const OSKShareableContentItemType_TextEditing;
 @property (copy, nonatomic) NSString *subject;
 
 /**
- The body text for the outgoing email. May be plain text or HTML markup. 
- 
+ The body text for the outgoing email. May be plain text or HTML markup.
+
  If HTML, the `isHTML` property must set to `YES`.
  */
 @property (copy, nonatomic) NSString *body;
@@ -249,7 +249,7 @@ extern NSString * const OSKShareableContentItemType_TextEditing;
 @property (assign, nonatomic) BOOL isHTML;
 
 /**
- An array of `UIImage` objects to attach to the outgoing message.
+ An array of `UIImage` or OSKMimeAttachment objects to attach to the outgoing message.
  */
 @property (copy, nonatomic) NSArray *attachments;
 
@@ -329,7 +329,7 @@ extern NSString * const OSKShareableContentItemType_TextEditing;
 
 /**
  Image content for copying & pasting. Setting this property will set all
- other properties to nil. 
+ other properties to nil.
  */
 @property (copy, nonatomic) NSArray *images;
 
@@ -377,7 +377,7 @@ extern NSString * const OSKShareableContentItemType_TextEditing;
 
 /**
  The title of the bookmark. Optional.
- 
+
  If left blank, `OSKPinboardActivity` will attempt to fetch
  the page title before sending the link to Pinboard.
  */
@@ -389,8 +389,8 @@ extern NSString * const OSKShareableContentItemType_TextEditing;
 @property (copy, nonatomic) NSString *notes;
 
 /**
- Option to flag a saved item as "to-read." 
- 
+ Option to flag a saved item as "to-read."
+
  Not all services may support this flag. At the very least, Pinboard does. It is
  recommended to set this to YES (it is YES by default).
  */

--- a/Projects/Static Library/OvershareKit/OvershareKit.xcodeproj/project.pbxproj
+++ b/Projects/Static Library/OvershareKit/OvershareKit.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		2EA7594318E5831E00078A1D /* OSKSaveToCameraRollActivity.m in Sources */ = {isa = PBXBuildFile; fileRef = 2EA7594218E5831E00078A1D /* OSKSaveToCameraRollActivity.m */; };
+		32C2B9B7190337BC0055C98B /* OSKMimeAttachment.m in Sources */ = {isa = PBXBuildFile; fileRef = 32C2B9B6190337BC0055C98B /* OSKMimeAttachment.m */; };
 		7F04946C188AFE5400BE7C4E /* NSString+OSKEmoji.m in Sources */ = {isa = PBXBuildFile; fileRef = 7F04946B188AFE5400BE7C4E /* NSString+OSKEmoji.m */; };
 		7F1DA9E0183C6B050082356D /* OSKLinkShorteningUtility.m in Sources */ = {isa = PBXBuildFile; fileRef = 7F1DA9DF183C6B050082356D /* OSKLinkShorteningUtility.m */; };
 		7F55A30C18425C6C004A3BCC /* OSKSession.m in Sources */ = {isa = PBXBuildFile; fileRef = 7F55A30518425C6C004A3BCC /* OSKSession.m */; };
@@ -145,6 +146,8 @@
 /* Begin PBXFileReference section */
 		2EA7594118E5831E00078A1D /* OSKSaveToCameraRollActivity.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OSKSaveToCameraRollActivity.h; sourceTree = "<group>"; };
 		2EA7594218E5831E00078A1D /* OSKSaveToCameraRollActivity.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OSKSaveToCameraRollActivity.m; sourceTree = "<group>"; };
+		32C2B9B5190337BC0055C98B /* OSKMimeAttachment.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OSKMimeAttachment.h; sourceTree = "<group>"; };
+		32C2B9B6190337BC0055C98B /* OSKMimeAttachment.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OSKMimeAttachment.m; sourceTree = "<group>"; };
 		7F04946A188AFE5400BE7C4E /* NSString+OSKEmoji.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSString+OSKEmoji.h"; sourceTree = "<group>"; };
 		7F04946B188AFE5400BE7C4E /* NSString+OSKEmoji.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSString+OSKEmoji.m"; sourceTree = "<group>"; };
 		7F19F901181F228200E5EA52 /* osk-iap-badge-60@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "osk-iap-badge-60@2x.png"; sourceTree = "<group>"; };
@@ -831,6 +834,8 @@
 				7FB34FEA1895ADBE0081C91A /* OSKXCallbackURLInfo.h */,
 				7F75BEFC1821539700D3681E /* UIImage+OSKUtilities.h */,
 				7F75BEFD1821539700D3681E /* UIImage+OSKUtilities.m */,
+				32C2B9B5190337BC0055C98B /* OSKMimeAttachment.h */,
+				32C2B9B6190337BC0055C98B /* OSKMimeAttachment.m */,
 			);
 			name = "Overshare Kit";
 			path = "../../../Overshare Kit";
@@ -1053,6 +1058,7 @@
 				7FEE78F2181ED8FE000F684A /* OSKTwitterText.m in Sources */,
 				7FEE78BB181ED8FE000F684A /* OSKActionSheet.m in Sources */,
 				7FEE78F4181ED8FE000F684A /* OSKTwitterUtility.m in Sources */,
+				32C2B9B7190337BC0055C98B /* OSKMimeAttachment.m in Sources */,
 				7FEE78B3181ED8FE000F684A /* NSHTTPURLResponse+OSKUtilities.m in Sources */,
 				7FEE78F3181ED8FE000F684A /* OSKTwitterTextEntity.m in Sources */,
 				7FEE78B2181ED8FE000F684A /* NSDictionary+OSKModel.m in Sources */,

--- a/Projects/iOS App/Overshare/Overshare.xcodeproj/project.pbxproj
+++ b/Projects/iOS App/Overshare/Overshare.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		32C2B9BA19033F350055C98B /* OSKMimeAttachment.m in Sources */ = {isa = PBXBuildFile; fileRef = 32C2B9B919033F350055C98B /* OSKMimeAttachment.m */; };
 		7F03EA2D18F5B8D000A4CEE4 /* OSKSaveToCameraRollActivity.m in Sources */ = {isa = PBXBuildFile; fileRef = 7F03EA2C18F5B8D000A4CEE4 /* OSKSaveToCameraRollActivity.m */; };
 		7F049469188AFE4600BE7C4E /* NSString+OSKEmoji.m in Sources */ = {isa = PBXBuildFile; fileRef = 7F049468188AFE4600BE7C4E /* NSString+OSKEmoji.m */; };
 		7F14C95618DB5D1D00E635FE /* OSKTextViewAttachment.m in Sources */ = {isa = PBXBuildFile; fileRef = 7F14C95518DB5D1D00E635FE /* OSKTextViewAttachment.m */; };
@@ -267,6 +268,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		32C2B9B819033F350055C98B /* OSKMimeAttachment.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OSKMimeAttachment.h; sourceTree = "<group>"; };
+		32C2B9B919033F350055C98B /* OSKMimeAttachment.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OSKMimeAttachment.m; sourceTree = "<group>"; };
 		7F03EA2B18F5B8D000A4CEE4 /* OSKSaveToCameraRollActivity.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OSKSaveToCameraRollActivity.h; sourceTree = "<group>"; };
 		7F03EA2C18F5B8D000A4CEE4 /* OSKSaveToCameraRollActivity.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OSKSaveToCameraRollActivity.m; sourceTree = "<group>"; };
 		7F049467188AFE4600BE7C4E /* NSString+OSKEmoji.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSString+OSKEmoji.h"; sourceTree = "<group>"; };
@@ -1395,6 +1398,8 @@
 		7FEE791A181EDB81000F684A /* Shareable Content */ = {
 			isa = PBXGroup;
 			children = (
+				32C2B9B819033F350055C98B /* OSKMimeAttachment.h */,
+				32C2B9B919033F350055C98B /* OSKMimeAttachment.m */,
 				7FEE7743181ED8EE000F684A /* OSKShareableContent.h */,
 				7FEE7744181ED8EE000F684A /* OSKShareableContent.m */,
 				7FEE7745181ED8EE000F684A /* OSKShareableContentItem.h */,
@@ -1763,6 +1768,7 @@
 				7FEE77C1181ED8EF000F684A /* OSKOmnifocusActivity.m in Sources */,
 				7FEE7794181ED8EF000F684A /* OSK1PasswordBrowserActivity.m in Sources */,
 				7FEE77C6181ED8EF000F684A /* OSKPresentationManager.m in Sources */,
+				32C2B9BA19033F350055C98B /* OSKMimeAttachment.m in Sources */,
 				7FEE77A1181ED8EF000F684A /* OSKActivitySheetViewController.m in Sources */,
 				7FEE77CA181ED8EF000F684A /* OSKSafariActivity.m in Sources */,
 				7FEE77AA181ED8EF000F684A /* OSKApplicationCredential.m in Sources */,


### PR DESCRIPTION
Currently there is only support for attaching images to email messages. Since I needed the ability to add files of different types, I added the ability the code attached to do so.

It adds a simple class to provide the attachment information which is then added when the mail compose view is created.
