### PR TITLE
Add google-plus-ios-sdk as a dependency

### DIFF
--- a/Overshare Kit/OSKGooglePlusActivity.m
+++ b/Overshare Kit/OSKGooglePlusActivity.m
@@ -7,8 +7,8 @@
 
 @import CoreMotion;
 
-#import <GooglePlus/GooglePlus.h>
-#import <GoogleOpenSource/GoogleOpenSource.h>
+#import <GooglePlus.h>
+#import <GoogleOpenSource.h>
 
 #import "OSKShareableContentItem.h"
 #import "OSKApplicationCredential.h"

--- a/OvershareKit.podspec
+++ b/OvershareKit.podspec
@@ -15,10 +15,9 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '7.0'
   
   s.source_files = ['Overshare Kit/*.{h,m}']
-  s.resources    = ['Overshare Kit/Images/*', 'Overshare Kit/*.xib', 'Dependencies/GooglePlus-SDK/GooglePlus.bundle']
+  s.resources    = ['Overshare Kit/Images/*', 'Overshare Kit/*.xib']
 
-  s.ios.vendored_frameworks = 'Dependencies/GooglePlus-SDK/GooglePlus.framework', 'Dependencies/GooglePlus-SDK/GoogleOpenSource.framework'
-  
   s.dependency 'ADNLogin'
   s.dependency 'PocketAPI'
+  s.dependency 'google-plus-ios-sdk'
 end


### PR DESCRIPTION
Without these changes my project fails to compile when installing OvershareKit through CocoaPods (tested on the 64bit simulator).
