### PR TITLE
Added delegate method for failed system account access

### DIFF
--- a/Overshare Kit/OSKSessionController.h
+++ b/Overshare Kit/OSKSessionController.h
@@ -33,6 +33,10 @@ willPresentSystemViewController:(UIViewController *)systemViewController;
 
 - (void)sessionControllerDidCancel:(OSKSessionController *)controller;
 
+@optional
+
+- (void)sessionController:(OSKSessionController *)controller failedSystemAccountAccessForActivity:(OSKActivity *)activity withDefaultHandler:(void (^)(void))defaultHandler;
+
 @end
 
 @interface OSKSessionController : NSObject


### PR DESCRIPTION
This adds a hook to take action when a user attempts to share and they don't have the appropriate system account set up for the activity type.  Currently, OSK just presents alert messages.

Use case: We find many users don't have Facebook accounts configured in iOS, so we use this hook to fallback to sharing via Facebook's SDK (also mentioned here: https://github.com/overshare/overshare-kit/issues/10#issuecomment-33438239)

If you don't implement the delegate, the standard alert messages show.  It also returns the default action (showing the alert) if you want to perform a custom action for a certain activity type, but trigger the default for others.
