### PR TITLE
Clearing "Unused entity" warning.

### DIFF
--- a/Overshare Kit/OSKActivityIndicatorItem.m
+++ b/Overshare Kit/OSKActivityIndicatorItem.m
@@ -38,6 +38,8 @@
 
 @implementation OSKActivityIndicatorItem
 
+@dynamic position;
+
 + (instancetype)item:(UIActivityIndicatorViewStyle)style {
     OSKActivityIndicatorView *spinner = [[OSKActivityIndicatorView alloc] initWithActivityIndicatorStyle:style];
     spinner.hidesWhenStopped = YES;


### PR DESCRIPTION
Fixing:

/Users/sclay/projects/newsblur/clients/ios/Other Sources/Overshare Kit/OSKActivityIndicatorItem.m:49:1: Ivar '_position' which backs the property is not referenced in this property's accessor.
