### PR TITLE
Fixing more "Unused entity" warnings

### DIFF
--- a/Overshare Kit/OSKPagedHorizontalLayout.m
+++ b/Overshare Kit/OSKPagedHorizontalLayout.m
@@ -20,6 +20,10 @@
 
 @implementation OSKPagedHorizontalLayout
 
+@dynamic availableWidth;
+@dynamic availableHeight;
+@dynamic edgeInsets;
+
 #pragma mark - Required Methods
 
 - (CGSize)collectionViewContentSize {


### PR DESCRIPTION
Fixes:

/Users/sclay/projects/newsblur/clients/ios/Other Sources/Overshare Kit/OSKPagedHorizontalLayout.m:67:1: Ivar '_edgeInsets' which backs the property is not referenced in this property's accessor
/Users/sclay/projects/newsblur/clients/ios/Other Sources/Overshare Kit/OSKPagedHorizontalLayout.m:71:1: Ivar '_availableWidth' which backs the property is not referenced in this property's accessor
/Users/sclay/projects/newsblur/clients/ios/Other Sources/Overshare Kit/OSKPagedHorizontalLayout.m:76:1: Ivar '_availableHeight' which backs the property is not referenced in this property's accessor
